### PR TITLE
Added skip to culling to the cemetery water plane

### DIFF
--- a/Patches/Patches.h
+++ b/Patches/Patches.h
@@ -779,6 +779,7 @@ void RunTreeColor();
 
 int GetNewScreenMode();
 
+void CheckCemeteryWaterCulling();
 void CheckFlashlightAvailable();
 float GetConditionalFlashlightBrightnessRed();
 float GetConditionalFlashlightBrightnessGreen();

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -25,6 +25,8 @@ DWORD vsDeclWater[] = {
 // eax == 3
 //eax, dword ptr[eax * 4 + 1DB9288h]
 static DWORD* g_vsHandles = nullptr;
+static BYTE* g_cemeteryWaterPlaneCheckFirstAddr = nullptr;
+static BYTE* g_cemeteryWaterPlaneCheckSecondAddr = nullptr;
 
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
 #define WATER_FVF               (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
@@ -486,16 +488,44 @@ void PatchWaterEnhancement()
     {
     case SH2V_10:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DB9288);
+        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D41A8 - 0x3C);
+        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D41A8 - 0x25);
         break;
     case SH2V_11:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DBCE88);
+        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D4458 - 0x3C);
+        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D4458 - 0x25);
         break;
     case SH2V_DC:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DBBE88);
+        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D3D18 - 0x3C);
+        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D3D18 - 0x25);
         break;
     case SH2V_UNKNOWN:
         Logging::Log() << __FUNCTION__ << " Error: unknown game version!";
         WaterEnhancedRender = false;
         return;
     }
+}
+
+void CheckCemeteryWaterCulling()
+{
+    if (!WaterEnhancedRender)
+		return;
+
+	static bool cemeteryWaterCullingDisabled = false;
+
+    if (!cemeteryWaterCullingDisabled && GetRoomID() == R_FOREST_CEMETERY) 
+    {
+
+		UpdateMemoryAddress(g_cemeteryWaterPlaneCheckFirstAddr, "\x01", 1);
+        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckSecondAddr, "\x01", 1);
+        cemeteryWaterCullingDisabled = true;
+	}
+    else if (cemeteryWaterCullingDisabled && GetRoomID() != R_FOREST_CEMETERY) 
+    {
+        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckFirstAddr, "\x00", 1);
+        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckSecondAddr, "\x00", 1);
+        cemeteryWaterCullingDisabled = false;
+	}
 }

--- a/Patches/WaterEnhancement.cpp
+++ b/Patches/WaterEnhancement.cpp
@@ -25,8 +25,8 @@ DWORD vsDeclWater[] = {
 // eax == 3
 //eax, dword ptr[eax * 4 + 1DB9288h]
 static DWORD* g_vsHandles = nullptr;
-static BYTE* g_cemeteryWaterPlaneCheckFirstAddr = nullptr;
-static BYTE* g_cemeteryWaterPlaneCheckSecondAddr = nullptr;
+static DWORD* g_cemeteryWaterPlaneCheckAddr = nullptr;
+static DWORD g_cemeteryWaterPlaneCheckValue = NULL;
 
 #define WATER_VSHADER_ORIGINAL  (g_vsHandles[3])
 #define WATER_FVF               (D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1)
@@ -488,18 +488,15 @@ void PatchWaterEnhancement()
     {
     case SH2V_10:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DB9288);
-        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D41A8 - 0x3C);
-        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D41A8 - 0x25);
+        g_cemeteryWaterPlaneCheckAddr = reinterpret_cast<DWORD*>(0x1F7AA2C);
         break;
     case SH2V_11:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DBCE88);
-        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D4458 - 0x3C);
-        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D4458 - 0x25);
+        g_cemeteryWaterPlaneCheckAddr = reinterpret_cast<DWORD*>(0x1F7E62C);
         break;
     case SH2V_DC:
         g_vsHandles = reinterpret_cast<DWORD*>(0x1DBBE88);
-        g_cemeteryWaterPlaneCheckFirstAddr = reinterpret_cast<BYTE*>(0x004D3D18 - 0x3C);
-        g_cemeteryWaterPlaneCheckSecondAddr = reinterpret_cast<BYTE*>(0x004D3D18 - 0x25);
+        g_cemeteryWaterPlaneCheckAddr = reinterpret_cast<DWORD*>(0x1F7D62C);
         break;
     case SH2V_UNKNOWN:
         Logging::Log() << __FUNCTION__ << " Error: unknown game version!";
@@ -517,15 +514,13 @@ void CheckCemeteryWaterCulling()
 
     if (!cemeteryWaterCullingDisabled && GetRoomID() == R_FOREST_CEMETERY) 
     {
-
-		UpdateMemoryAddress(g_cemeteryWaterPlaneCheckFirstAddr, "\x01", 1);
-        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckSecondAddr, "\x01", 1);
+		ReadMemoryAddress(g_cemeteryWaterPlaneCheckAddr, &g_cemeteryWaterPlaneCheckValue, sizeof(DWORD));
+        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckAddr, "\x00\x04\x00\x00", sizeof(DWORD));
         cemeteryWaterCullingDisabled = true;
 	}
     else if (cemeteryWaterCullingDisabled && GetRoomID() != R_FOREST_CEMETERY) 
     {
-        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckFirstAddr, "\x00", 1);
-        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckSecondAddr, "\x00", 1);
+        UpdateMemoryAddress(g_cemeteryWaterPlaneCheckAddr, &g_cemeteryWaterPlaneCheckValue, sizeof(DWORD));
         cemeteryWaterCullingDisabled = false;
 	}
 }

--- a/Wrappers/d3d8/IDirect3DDevice8.cpp
+++ b/Wrappers/d3d8/IDirect3DDevice8.cpp
@@ -1711,6 +1711,9 @@ HRESULT m_IDirect3DDevice8::Present(CONST RECT* pSourceRect, CONST RECT* pDestRe
 		OverlayRef.RenderMouseCursor();
 	}
 
+	// Fix water plane culling in Cemetery cutscene
+	CheckCemeteryWaterCulling();
+
 	// Fix pause menu before drawing scaled surface
 	bool PauseMenuFlag = FixPauseMenuOnPresent();
 


### PR DESCRIPTION
Hello!

This PR is to skip the water plane's culling in the cemetery.

The function at FUN_004d40b0 is responsible for this, the fix neutralizes two (distance?) checks having them set a flag to 1 even if triggered instead of 0.

Cheers!